### PR TITLE
Remove capture attribute to allow photo library and file selection on iOS

### DIFF
--- a/components/CoffeePhotoUpload.tsx
+++ b/components/CoffeePhotoUpload.tsx
@@ -176,7 +176,6 @@ export function CoffeePhotoUpload({ onIdentified, onSkip }: CoffeePhotoUploadPro
             type="file"
             accept="image/jpeg,image/png,image/webp"
             multiple
-            capture="environment"
             onChange={handleFileChange}
             className="hidden"
           />


### PR DESCRIPTION
The capture="environment" attribute forced mobile Safari to open the camera
directly. Removing it lets iOS show the standard picker with options for
Take Photo, Photo Library, and Choose File.

https://claude.ai/code/session_018G1ecFJ68LZ5cqA6PSH4r1