### PR TITLE
Fix roast date not populating from photo ID

### DIFF
--- a/app/tastings/new/page.tsx
+++ b/app/tastings/new/page.tsx
@@ -41,7 +41,17 @@ export default function NewTastingPage() {
 
   const handleIdentified = (response: CoffeeIdentificationResponse) => {
     setIdentification(response)
-    if (response.roast_date) setRoastDate(response.roast_date)
+    if (response.roast_date) {
+      const parsed = new Date(response.roast_date)
+      if (!isNaN(parsed.getTime())) {
+        const yyyy = parsed.getFullYear()
+        const mm = String(parsed.getMonth() + 1).padStart(2, '0')
+        const dd = String(parsed.getDate()).padStart(2, '0')
+        setRoastDate(`${yyyy}-${mm}-${dd}`)
+      } else {
+        setRoastDate(response.roast_date)
+      }
+    }
     if (response.lot_number) setLotNumber(response.lot_number)
   }
 


### PR DESCRIPTION
## Summary
- The identify-coffee API returns `roast_date` as a human-readable string (e.g. `"FEB 19 2024"`) but the `<input type="date">` expects `YYYY-MM-DD` format
- Parse the date string into ISO format so the roast date field actually populates after photo identification

## Test plan
- [ ] Upload a coffee bag photo that includes a roast date
- [ ] Verify the roast date field populates correctly in the Bag Info section

🤖 Generated with [Claude Code](https://claude.com/claude-code)