### PR TITLE
fix roast date not populating from coffee identification

### DIFF
--- a/app/tastings/new/page.tsx
+++ b/app/tastings/new/page.tsx
@@ -41,7 +41,17 @@ export default function NewTastingPage() {
 
   const handleIdentified = (response: CoffeeIdentificationResponse) => {
     setIdentification(response)
-    if (response.roast_date) setRoastDate(response.roast_date)
+    if (response.roast_date) {
+      const parsed = new Date(response.roast_date)
+      if (!isNaN(parsed.getTime())) {
+        const yyyy = parsed.getFullYear()
+        const mm = String(parsed.getMonth() + 1).padStart(2, '0')
+        const dd = String(parsed.getDate()).padStart(2, '0')
+        setRoastDate(`${yyyy}-${mm}-${dd}`)
+      } else {
+        setRoastDate(response.roast_date)
+      }
+    }
     if (response.lot_number) setLotNumber(response.lot_number)
   }
 


### PR DESCRIPTION
The identify-coffee API returns roast_date as a human-readable string
(e.g. "FEB 19 2024") but the date input expects YYYY-MM-DD format.
Parse the string into ISO date format before setting state.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>